### PR TITLE
add support for Bcc

### DIFF
--- a/django_sendmail_backend/backends.py
+++ b/django_sendmail_backend/backends.py
@@ -26,11 +26,12 @@ class EmailBackend(BaseEmailBackend):
 
     def _send(self, email_message):
         """A helper method that does the actual sending."""
-        if not email_message.recipients():
+        recipients = email_message.recipients()
+        if not recipients:
             return False
         try:
             # -t: Read message for recipients
-            ps = Popen(['/usr/sbin/sendmail', '-t'], stdin=PIPE, stderr=PIPE)
+            ps = Popen(['/usr/sbin/sendmail'] + recipients, stdin=PIPE, stderr=PIPE)
             ps.stdin.write(email_message.message().as_bytes())
             (stdout, stderr) = ps.communicate()
         except:


### PR DESCRIPTION
Django splits out the 'Bcc:' header from a message, and that is why sender have to list recipients explicitly in the sendmail commandline args.

Here is a supportive link: https://code.djangoproject.com/ticket/18582