### PR TITLE
Add SENDMAIL_BINARY setting for systems with sendmail in an unusual location

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,16 @@ Set the EMAIL_BACKEND var in your settings module
 
     EMAIL_BACKEND = 'django_sendmail_backend.backends.EmailBackend'
 
+If your sendmail binary is not at /usr/sbin/sendmail (see MTA section below),
+you'll also need to set
+
+    SENDMAIL_BINARY = '/path/to/sendmail'
+
 
 # MTA
 
-You will need any mta installed (like postfix or exim) and a executable **sendmail** command
-in your bin path.
+You will need any mta installed (like postfix or exim) and a executable
+**sendmail** command.
 
 Try to install [msmtp](http://msmtp.sourceforge.net/) for test
 

--- a/django_sendmail_backend/backends.py
+++ b/django_sendmail_backend/backends.py
@@ -3,6 +3,7 @@ Sendmail email backend class.
 
 Credits: https://djangosnippets.org/snippets/1864/
 """
+from django.conf import settings
 from django.core.mail.backends.base import BaseEmailBackend
 from subprocess import Popen, PIPE
 
@@ -27,11 +28,13 @@ class EmailBackend(BaseEmailBackend):
     def _send(self, email_message):
         """A helper method that does the actual sending."""
         recipients = email_message.recipients()
+        sendmail_binary = getattr(settings, 'SENDMAIL_BINARY',
+                                  '/usr/sbin/sendmail')
         if not recipients:
             return False
         try:
             # -t: Read message for recipients
-            ps = Popen(['/usr/sbin/sendmail'] + recipients, stdin=PIPE, stderr=PIPE)
+            ps = Popen([sendmail_binary] + recipients, stdin=PIPE, stderr=PIPE)
             ps.stdin.write(email_message.message().as_bytes())
             (stdout, stderr) = ps.communicate()
         except:


### PR DESCRIPTION
Previously, the path to sendmail was hardcoded to /usr/sbin. This meant django-sendmail-backend didn't work on, for example, nearlyfreespeech.net shared hosting, which has sendmail in /usr/bin. This change adds a setting, SENDMAIL_BINARY, that lets the developer specify another path to sendmail.

Testing: WFM